### PR TITLE
Fork and rename x86 emulation and socketcall argsize bugfix

### DIFF
--- a/compose_reaction
+++ b/compose_reaction
@@ -70,7 +70,6 @@ if __name__ == "__main__":
             del atom['name']
             atom_cb = 0
             atom_blob = b''
-            fork_and_rename_depth = 0;
             for k, v in atom.items():
                 quark = b''
                 if ':' in k:
@@ -83,11 +82,12 @@ if __name__ == "__main__":
                     method = { 'execve' : 1, 'execveat' : 2  }.get(k)
                     type = 'exec'
                     quark += pack("<L", method) + parse_argv(v)
-                elif k == 'fork-and-rename':
+                elif k == 'fork-and-rename' or k == 'fork-and-rename-x86':
+                    type = 'fork-and-rename'
                     assert isinstance(v, list), '{} argument must be a list'.format(k)
                     assert len(v) > 0, '{} must have arguments'.format(k)
-                    fork_and_rename_depth += 1
-                    quark += pack("<L", fork_and_rename_depth) + parse_argv(v)
+                    method = { 'fork-and-rename': 2, 'fork-and-rename-x86' : 1 }.get(k)
+                    quark += pack("<L", method) + parse_argv(v)
                 elif k == 'connect' or k == 'listen':
                     method = { 'syscall' : 1, 'socketcall' : 2  }.get(v.get('method'))
                     socket_type = { 'tcp4' : SOCKET_TYPE_TCP | SOCKET_TYPE_IPV4,

--- a/src/atoms.h
+++ b/src/atoms.h
@@ -31,6 +31,9 @@ typedef char byte_t;
 #define EXEC_METHOD_PATH 1
 #define EXEC_METHOD_DESCRIPTOR 2
 
+#define FORK_METHOD_X86 1
+#define FORK_METHOD_LIBC 2
+
 #define SOCKET_METHOD_SYSCALL 1
 #define SOCKET_METHOD_SOCKETCALL 2
 
@@ -46,7 +49,7 @@ typedef struct {
 } exec_t, *pexec_t;
 
 typedef struct {
-    int depth;
+    int method;
     byte_t argv[];
 } fork_and_rename_t, *pfork_and_rename_t;
 

--- a/src/networking_quarks.c
+++ b/src/networking_quarks.c
@@ -76,7 +76,7 @@ THE SOFTWARE.
 
 // It is possible to configure a Linux kernel that does not support syscall
 // emulation, however it is highly unlikely to occur in main distros.
-int x86_int0x80(int syscall, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5)
+static int x86_int0x80(int syscall, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5)
 {
     int ret_value;
     asm volatile("int $0x80"
@@ -89,7 +89,7 @@ int x86_int0x80(int syscall, void* arg1, void* arg2, void* arg3, void* arg4, voi
 // Chances are, none of these are to be more than a single page, but still trying
 // to be "correct"
 #define ALLOC_SOCKETCALL_ARGS(SIZE) \
-size_t cb_args = sizeof(int)*3; \
+size_t cb_args = (SIZE); \
 void* args = mmap(NULL, \
     cb_args, \
     PROT_READ | PROT_WRITE, \
@@ -199,7 +199,7 @@ int socketcall_connect(int sockfd, const struct sockaddr *addr, socklen_t addrle
 
 int socketcall_listen(int sockfd, int backlog)
 {
-    ALLOC_SOCKETCALL_ARGS(sizeof(int)*2 + addrlen);
+    ALLOC_SOCKETCALL_ARGS(sizeof(int)*2);
 
     ((int*)args)[0] = sockfd;
     ((int*)args)[1] = backlog;


### PR DESCRIPTION
Added x86 support for fork-and-rename, fixed a bug that probably will never occur with the ALLOC_SOCKETCALL_ARGS macro considering that SIZE will never be more than 4096.