### PR TITLE
docs(README.md): fix atoms.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ Let’s start with a basic chain reaction:
 `atoms.json`
 
 ```
-{
-    "name" : "HIDDEN-PROCESS-EXEC",
-    "execve" : [ "mkdir”, “-p”, “/tmp/.hidden” ],
-    "copy" : [ “/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
-    "execveat" : [ "/tmp/.hidden/.chain_reactor_hidden", "exit" ],
-    "remove" : [ "/tmp/.hidden" ]
-}
+[
+    {
+        "name" : "HIDDEN-PROCESS-EXEC",
+        "execve" : [ "mkdir”, “-p”, “/tmp/.hidden” ],
+        "copy" : [ “/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
+        "execveat" : [ "/tmp/.hidden/.chain_reactor_hidden", "exit" ],
+        "remove" : [ "/tmp/.hidden" ]
+    }
+]
 ```
 
 To build the ELF executable, we run the following:


### PR DESCRIPTION
The current README.md example for an atoms.json file doesn't include the outer brackets, leading to a parsing issue:
```
python3 compose_reaction atoms.json reaction.json test_reaction
Traceback (most recent call last):                                                                                                                                                                                
  File "compose_reaction", line 87, in <module>                                                                                                                                                                   
    name = atom.get('name')                                                                                                                                                                                       
AttributeError: 'str' object has no attribute 'get'
```