### PR TITLE
Fix quotes in README.md atoms.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ Let’s start with a basic chain reaction:
 `atoms.json`
 
 ```
-{
-    "name" : "HIDDEN-PROCESS-EXEC",
-    "execve" : [ "mkdir”, “-p”, “/tmp/.hidden” ],
-    "copy" : [ “/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
-    "execveat" : [ "/tmp/.hidden/.chain_reactor_hidden", "exit" ],
-    "remove" : [ "/tmp/.hidden" ]
-}
+[
+    {
+        "name" : "HIDDEN-PROCESS-EXEC",
+        "execve" : [ "mkdir”, “-p”, “/tmp/.hidden” ],
+        "copy" : [ “/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
+        "execveat" : [ "/tmp/.hidden/.chain_reactor_hidden", "exit" ],
+        "remove" : [ "/tmp/.hidden" ]
+    }
+]
 ```
 
 To build the ELF executable, we run the following:

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Let’s start with a basic chain reaction:
 [
     {
         "name" : "HIDDEN-PROCESS-EXEC",
-        "execve" : [ "mkdir”, “-p”, “/tmp/.hidden” ],
-        "copy" : [ “/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
+        "execve" : [ "mkdir", "-p", "/tmp/.hidden" ],
+        "copy" : [ "/proc/self/exe", "/tmp/.hidden/.chain_reactor_hidden" ],
         "execveat" : [ "/tmp/.hidden/.chain_reactor_hidden", "exit" ],
         "remove" : [ "/tmp/.hidden" ]
     }


### PR DESCRIPTION
Closes #14, originally found in #13 