### PR TITLE
Added sleep quark

### DIFF
--- a/compose_reaction
+++ b/compose_reaction
@@ -31,7 +31,7 @@ import os
 
 supported_quarks = ['execve', 'execveat', 'fork-and-rename',
     'connect', 'listen', 'copy', 'remove', 'chown', 'fchown', 'fchownat', 'lchown',
-    'chmod', 'fchmod', 'fchmodat', 'file-touch', 'file-append', 'file-prepend', 'file-create' ]
+    'chmod', 'fchmod', 'fchmodat', 'file-touch', 'file-append', 'file-prepend', 'file-create', 'sleep' ]
 
 class AtomDecoder(JSONDecoder):
     def __init__(self, *args, **kwargs):
@@ -168,6 +168,11 @@ if __name__ == "__main__":
 
                     quark += pack("<L260sL", file_op_flags,
                         v.get('path').encode('utf8'), len(data)) + data
+                elif k == 'sleep':
+                    type = 'sleep'
+                    assert isinstance(v, int), '{} argument must be an integer'.format(k)
+                    assert v > 0, '{} argument must be positive'.format(k)
+                    quark += pack("<L", v)
                 else:
                     raise Exception("unknown quark {}".format(k))
 

--- a/src/atoms.c
+++ b/src/atoms.c
@@ -44,6 +44,8 @@ int quark_copy(pcopy_t args);
 int quark_chmod(pchmod_t args);
 int quark_chown(pchown_t args);
 int quark_file_op(pfile_op_t args);
+void quark_sleep(psleep_t args);
+
 
 int split_atom(patom_t atom, int in_fork_and_rename)
 {
@@ -111,6 +113,8 @@ int split_atom(patom_t atom, int in_fork_and_rename)
             if (-1 == quark_chown((pchown_t)quark_body)) {
                 goto Exit;
             }
+        } else if (!strcasecmp("sleep", quark->type)) {
+            quark_sleep((psleep_t)quark_body);
         } else {
             ERROR("unknown quark type %s\n", quark->type);
             errno = EINVAL;

--- a/src/atoms.h
+++ b/src/atoms.h
@@ -101,6 +101,10 @@ typedef struct {
 } quark_t, *pquark_t ;
 
 typedef struct {
+    unsigned int seconds;
+} sleep_t, *psleep_t;
+
+typedef struct {
     unsigned int cb;
     char name[64];
     unsigned int num_quarks;

--- a/src/quarks.c
+++ b/src/quarks.c
@@ -568,3 +568,12 @@ Exit:
 
     return err;
 }
+
+void quark_sleep(psleep_t args)
+{
+    unsigned int seconds = 0;
+
+    seconds = args->seconds;
+    LOGY("\tquark: sleep seconds=%d\n", seconds);
+    sleep(seconds);
+}


### PR DESCRIPTION
Closes #29 

I think I did this right. Added a new quark, `sleep`, which takes a positive integer and calls the `sleep()` system function. 

The atom can be defined like so:
```
    {
        "name": "WAIT",
        "sleep": 3
    }
```

And it should spit out a log indicating how many seconds it sleeps
<img width="759" alt="Screen Shot 2021-09-02 at 1 30 11 PM" src="https://user-images.githubusercontent.com/59621072/131904889-a6795e46-587e-443c-8b9d-348c7f30299a.png">
