### PR TITLE
Optionally avoid wordexp when not needed

### DIFF
--- a/compose_reaction
+++ b/compose_reaction
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     parser.add_argument("reaction_file", help="The path to the reaction chain file.")
     parser.add_argument("output", help="The path to where the completed reaction should be written")
     parser.add_argument("--no-banner", action="store_true", help="Do not display the Red Canary banner on execution")
+    parser.add_argument("--no-wordexp", action="store_true", help="Do not shell-expand parameters for exec quarks")
 
     options = parser.parse_args()
 
@@ -75,6 +76,8 @@ if __name__ == "__main__":
 
         if options.no_banner:
             settings_flags |= (1 << 0)
+        if options.no_wordexp:
+            settings_flags |= (1 << 1)
 
         settings_section = pack("<L", settings_flags)
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,10 +37,9 @@ THE SOFTWARE.
 
 #include "util.h"
 #include "atoms.h"
+#include "settings.h"
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
-
-#define FLAGS_NO_BANNER (1 << 0)
 
 typedef struct {
     char name[64];
@@ -92,6 +91,11 @@ static void initialize()
     g_reactions = (preactions_t)((char*)g_atoms + g_atoms->cb);
 }
 
+int check_settings_flag(unsigned int flag)
+{
+  return (g_settings->flags & flag);
+}
+
 void main(int argc, char** argv)
 {
     char transform[33] = {0};
@@ -114,7 +118,7 @@ void main(int argc, char** argv)
     initialize();
 
     if (!in_fork_and_rename) {
-        if (!(g_settings->flags & FLAGS_NO_BANNER)) {
+        if (!check_settings_flag(FLAGS_NO_BANNER)) {
             LOG("%s", red_canary());
         }
         LOGB("chain reaction" ANSI_COLOR_CYAN " \"%s\"" ANSI_COLOR_RESET " %d %d\n",

--- a/src/quarks.c
+++ b/src/quarks.c
@@ -46,6 +46,7 @@ THE SOFTWARE.
 
 #include "atoms.h"
 #include "util.h"
+#include "settings.h"
 
 int quark_connect(pconnect_t args);
 int quark_listen(plisten_t args);
@@ -94,8 +95,9 @@ int quark_exec(pexec_t args)
     // +1 so the syscalls are happy, they expect a null terminated array
     expanded_argv = (char**)calloc(argc + 1, sizeof(*expanded_argv));
 
+    int no_wordexp = check_settings_flag(FLAGS_NO_WORDEXP);
     for (int jj = 0; jj < argc; ++jj) {
-        if (wordexp(argv[jj], &expanded_arg, WRDE_REUSE)) {
+        if (no_wordexp || wordexp(argv[jj], &expanded_arg, WRDE_REUSE)) {
             expanded_argv[jj] = strdup(argv[jj]);
         } else {
             expanded_argv[jj] = strdup(expanded_arg.we_wordv[0]);

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,33 @@
+/*
+
+The MIT License
+
+Copyright (c) 2020 Red Canary, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+#pragma once
+
+#define FLAGS_NO_BANNER (1 << 0)
+#define FLAGS_NO_WORDEXP (1 << 1)
+
+// Returns a nonzero value if the given flag is set in the settings
+int check_settings_flag(unsigned int flag);


### PR DESCRIPTION
The musl implementation of wordexp launches a shell to do a printf for each command line parameter we try to expand, which can be pretty noisy in telemetry. This shuts it off globally via a config flag.

It might be nice to be able to enable/disable on a finer-grained basis, but doing the config for that seemed like more trouble than it's worth right now.